### PR TITLE
I was getting an odd error when trying to load anything (check http://oi5

### DIFF
--- a/lib/padrino/sprockets.rb
+++ b/lib/padrino/sprockets.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require "sprockets/environment"
+require "sprockets/version"
 module Padrino
   module Sprockets
     class << self


### PR DESCRIPTION
I was getting an odd error when trying to load anything (check http://oi52.tinypic.com/2d7g9r6.jpg -strangely the error appears like an image :S!!).

Still, change the require to require 'sprockets' or adding sprockets/version (like the change I'm proposing here) works fine.

Is there a particular reason why you aren't requiring the whole library?

By the way, I've setup my app in the simplest way (as you specify on the docs).
Cheers!
