### PR TITLE
Add support for importing Compass etc. in your SASS

### DIFF
--- a/lib/padrino/sprockets.rb
+++ b/lib/padrino/sprockets.rb
@@ -30,6 +30,11 @@ module Padrino
         @environment.append_path 'assets/javascripts'
         @environment.append_path 'assets/stylesheets'
         @environment.append_path 'assets/images'
+        if @app.settings.sprockets_paths
+          @app.settings.sprocket_paths.each do |sprocket_path|
+            @environment.append_path sprocket_path
+          end
+        end
       end
       def call(env)
         return @app.call(env) unless @matcher =~ env["PATH_INFO"]

--- a/lib/padrino/sprockets.rb
+++ b/lib/padrino/sprockets.rb
@@ -12,8 +12,9 @@ module Padrino
         def sprockets(options={})
           url   = options[:url] || 'assets'
           _root = options[:root] || root
+          paths = options[:paths] || []
           set :sprockets_url, url
-          use Padrino::Sprockets::App,:root => _root,:url => url
+          use Padrino::Sprockets::App,:root => _root,:url => url, :paths => paths
         end
       end
       def self.included(base)
@@ -30,10 +31,8 @@ module Padrino
         @environment.append_path 'assets/javascripts'
         @environment.append_path 'assets/stylesheets'
         @environment.append_path 'assets/images'
-        if @app.settings.sprockets_paths
-          @app.settings.sprocket_paths.each do |sprocket_path|
-            @environment.append_path sprocket_path
-          end
+        options[:paths].each do |sprocket_path|
+          @environment.append_path sprocket_path
         end
       end
       def call(env)


### PR DESCRIPTION
I use Compass in a lot of projects. This pull request gives you the ability to pass additional load paths in, which means you get to use a variety of other SASS/SCSS utilities, including Compass.

To see this in action:

Gemfile:

```
gem 'compass'
```

In your Padrino app:

```
class MyApp < Padrino::Application
  register Padrino::Sockets
  sprockets :paths => [Compass::Frameworks['compass'].stylesheets_directory]
  ...
```

In app/assets/application.css.scss file:

```
@import "compass/reset";
```

See that /assets/application.css in a browser gives you the Compass reset.
