### PR TITLE
Add support for JSMin

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,19 @@ Now you can access the assets as follows:
       => app/assets/javascripts/application.js.coffee
        => app/assets/javascripts/application.js.erb
     
+To minify javascripts in production do the following:
+    
+In your Gemfile:
+    
+    gem 'jsmin'
+
+In your app:
+
+    class Redstore < Padrino::Application
+      register Padrino::Sprockets
+      sprockets :minify => (Padrino.env == :production)
+    end
+
 For more documentation about sprockets, please check [Sprockets](https://github.com/sstephenson/sprockets/)
 
 # Helpers Usage #

--- a/lib/padrino/sprockets.rb
+++ b/lib/padrino/sprockets.rb
@@ -45,9 +45,9 @@ module Padrino
         @environment.append_path 'assets/stylesheets'
         @environment.append_path 'assets/images'
         if options[:minify]
-          if defined?(JSMin)
+          #if defined?(JSMin)
             @environment.register_postprocessor "application/javascript", ::Sprockets::JSMinifier
-          end
+          #end
         end
         options[:paths].each do |sprocket_path|
           @environment.append_path sprocket_path

--- a/lib/padrino/sprockets.rb
+++ b/lib/padrino/sprockets.rb
@@ -1,5 +1,18 @@
 # encoding: utf-8
 require "sprockets/environment"
+require "tilt"
+
+module Sprockets
+  class JSMinifier < Tilt::Template
+    def prepare
+    end
+
+    def evaluate(context, locals, &block)
+      JSMin.minify(data)
+    end
+  end
+end
+
 module Padrino
   module Sprockets
     class << self
@@ -30,6 +43,11 @@ module Padrino
         @environment.append_path 'assets/javascripts'
         @environment.append_path 'assets/stylesheets'
         @environment.append_path 'assets/images'
+        if options[:minify]
+          if defined?(JSMin)
+            @environment.register_postprocessor "application/javascript", ::Sprockets::JSMinifier
+          end
+        end
       end
       def call(env)
         return @app.call(env) unless @matcher =~ env["PATH_INFO"]

--- a/lib/padrino/sprockets.rb
+++ b/lib/padrino/sprockets.rb
@@ -27,7 +27,10 @@ module Padrino
           _root = options[:root] || root
           paths = options[:paths] || []
           set :sprockets_url, url
-          use Padrino::Sprockets::App,:root => _root,:url => url, :paths => paths
+          options[:root] = _root
+          options[:url] = url
+          options[:paths] = paths
+          use Padrino::Sprockets::App, options
         end
       end
       def self.included(base)
@@ -45,9 +48,11 @@ module Padrino
         @environment.append_path 'assets/stylesheets'
         @environment.append_path 'assets/images'
         if options[:minify]
-          #if defined?(JSMin)
+          if defined?(JSMin)
             @environment.register_postprocessor "application/javascript", ::Sprockets::JSMinifier
-          #end
+          else
+            puts "Add jsmin to your Gemfile to enable minification"
+          end
         end
         options[:paths].each do |sprocket_path|
           @environment.append_path sprocket_path


### PR DESCRIPTION
I wanted to use padrino-sprockets in production, but I needed JS assets to be minified for me.

I've added a jsmin postprocessor that optionally gets used if you pass `:minify => true` in the options hash.
