### PR TITLE
Overwrite the asset_folder_name method in Padrino

### DIFF
--- a/lib/padrino/sprockets.rb
+++ b/lib/padrino/sprockets.rb
@@ -36,6 +36,16 @@ module Padrino
       def self.included(base)
         base.extend         ClassMethods
       end
+      module AssetTagHelpers
+        # Change the folders to /assets/
+        def asset_folder_name(kind)
+          case kind
+          when :css then 'assets'
+          when :js  then 'assets'
+          else kind.to_s
+          end
+        end
+      end # AssetTagHelpers
     end #Helpers
     class App
       def initialize(app, options={})


### PR DESCRIPTION
When using the `stylesheet_link_tag` or `javascript_include_tag` method Padrino defaults to /stylesheets/ and /javascripts/, this fix changes them to assets so it works as expected.
