### PR TITLE
Add css compression via yui-compressor 

### DIFF
--- a/lib/padrino/sprockets.rb
+++ b/lib/padrino/sprockets.rb
@@ -58,6 +58,11 @@ module Padrino
         @environment.append_path 'assets/stylesheets'
         @environment.append_path 'assets/images'
         if options[:minify]
+          if defined?(YUI)
+            @environment.css_compressor = YUI::CssCompressor.new
+          else
+            puts "Add yui-compressor to your Gemfile to enable css compression"
+          end
           if defined?(JSMin)
             @environment.register_postprocessor "application/javascript", ::Sprockets::JSMinifier
           else


### PR DESCRIPTION
I wanted yui-compressor to minify my css so I just add it together with the js compression when `options[:minify]` is given
