### PR TITLE
Update js minification process to use uglifier instead of jsmin

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Now you can access the assets as follows:
 To minify javascripts in production do the following:
 
 In your Gemfile:
-
-    gem 'jsmin'
+    # enable js minification
+    gem 'uglifier'
     # enable css compression
     gem 'yui-compressor'
 

--- a/lib/padrino/sprockets.rb
+++ b/lib/padrino/sprockets.rb
@@ -8,7 +8,7 @@ module Sprockets
     end
 
     def evaluate(context, locals, &block)
-      JSMin.minify(data)
+      Uglifier.compile(data, :comments => :none)
     end
   end
 end
@@ -69,10 +69,10 @@ module Padrino
           else
             puts "Add yui-compressor to your Gemfile to enable css compression"
           end
-          if defined?(JSMin)
+          if defined?(Uglifier)
             @environment.register_postprocessor "application/javascript", ::Sprockets::JSMinifier
           else
-            puts "Add jsmin to your Gemfile to enable minification"
+            puts "Add uglifier to your Gemfile to enable js minification"
           end
         end
 


### PR DESCRIPTION
I made a couple small updates to get rid of jsmin and use uglifier instead. I tried using yui for js minification but it threw errors when testing locally with my coffeescript files. Using uglifier worked great with my coffeescript files. The uglifier gem seems to be actively maintained which is why I chose it for js minification. This commit should resolve issue #17.

I did not add any tests. The [sinatra-assetpack](https://github.com/rstacruz/sinatra-assetpack) library seems to have some good tests for their asset pipeline so perhaps we could use a similar approach for unit testing.
