### PR TITLE
added ability to specify asset compressor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Register sprockets in your application:
 ```ruby
 class Redstore < Padrino::Application
   register Padrino::Sprockets
-  sprockets  # :url => 'assets', :root => app.root
+  sprockets  # :url => 'assets', :root => app.root, :js_compressor=>:uglify, :css_compressor=>:closure
 end
 ```
 
@@ -41,13 +41,14 @@ Now when requesting a path like `/assets/application.js` it will look for a sour
 * `app/assets/javascripts/application.js.coffee`
 * `app/assets/javascripts/application.js.erb`
 
-To minify javascripts in production do the following:
+#### To minify javascripts in production do the following:
 
 In your Gemfile:
 
 ```ruby
 # enable js minification
 gem 'uglifier'
+#gem 'closure'
 # enable css compression
 gem 'yui-compressor'
 ```
@@ -57,11 +58,33 @@ In your app:
 ```ruby
 class Redstore < Padrino::Application
   register Padrino::Sprockets
-  sprockets :minify => (Padrino.env == :production)
+  sprockets :minify => (Padrino.env == :production), :js_compressor => :yui # can be any of the shorthand 
 end
 ```
 
-For more documentation about sprockets, have a look at the [Sprockets](https://github.com/sstephenson/sprockets/) gem.
+For more documentation about sprockets nd its builtin shorthands for compressors, 
+have a look at the [Sprockets](https://github.com/sstephenson/sprockets/) gem.
+
+To use a custom javascript compressor, you can pass the classname instead of a shorthand.
+The class must have the same methods as one of the *Compressor classes in Sprockets, like
+ClosurCompressor and should be required in your App class. See the [Sprockets source code](https://github.com/sstephenson/sprockets/)
+for more on this.
+
+```ruby
+class Redstore < Padrino::Application
+  register Padrino::Sprockets
+  sprockets :minify => (Padrino.env == :production), :js_compressor => MyCustomCompressor 
+end
+```
+You can use a custom CSS compressor by specifying the :css_compressor for sprockets. You can
+use Sprockets's shorthand, or pass a custom compressor class instance.
+
+```ruby
+class Redstore < Padrino::Application
+  register Padrino::Sprockets
+  sprockets :minify => (Padrino.env == :production), :css_compressor => MyCustomCssCompressor.new
+end
+```
 
 ## Helpers Usage
 

--- a/lib/padrino/sprockets.rb
+++ b/lib/padrino/sprockets.rb
@@ -17,7 +17,7 @@ module Padrino
   module Sprockets
     module Helpers
       module ClassMethods
-        def sprockets(options={})
+        def sprockets(options={},&block)
           url   = options[:url] || 'assets'
           _root = options[:root] || root
           paths = options[:paths] || []
@@ -25,7 +25,7 @@ module Padrino
           options[:root] = _root
           options[:url] = url
           options[:paths] = paths
-          use Padrino::Sprockets::App, options
+          use Padrino::Sprockets::App, options, &block
         end
       end
 
@@ -49,15 +49,15 @@ module Padrino
     class App
       attr_reader :environment
 
-      def initialize(app, options={})
+      def initialize(app, options={},&block)
         @app = app
         @root = options[:root]
         url   =  options[:url] || 'assets'
         @matcher = /^\/#{url}\/*/
-        setup_environment(options[:minify],options)
+        setup_environment(options[:minify],options,&block)
       end
 
-      def setup_environment(minify=false, options={})
+      def setup_environment(minify=false, options={},&block)
         @environment = ::Sprockets::Environment.new(@root)
         @environment.append_path 'assets/javascripts'
         @environment.append_path 'assets/stylesheets'
@@ -79,6 +79,9 @@ module Padrino
         options[:paths].each do |sprocket_path|
           @environment.append_path sprocket_path
         end
+
+        block.call @environment if block
+
       end
 
       def call(env)

--- a/lib/padrino/sprockets.rb
+++ b/lib/padrino/sprockets.rb
@@ -54,29 +54,29 @@ module Padrino
         @root = options[:root]
         url   =  options[:url] || 'assets'
         @matcher = /^\/#{url}\/*/
-        setup_environment(options[:minify], options[:paths] || [])
+        setup_environment(options[:minify],options)
       end
 
-      def setup_environment(minify=false, extra_paths=[])
+      def setup_environment(minify=false, options={})
         @environment = ::Sprockets::Environment.new(@root)
         @environment.append_path 'assets/javascripts'
         @environment.append_path 'assets/stylesheets'
         @environment.append_path 'assets/images'
 
         if minify
-          if defined?(YUI)
-            @environment.css_compressor = YUI::CssCompressor.new
+          if css_compressor = (options[:css_compressor] || YUI::CssCompressor.new)
+            @environment.css_compressor = css_compressor
           else
-            puts "Add yui-compressor to your Gemfile to enable css compression"
+            puts "Add yui-compressor to your Gemfile or specify :css_compressor for sprockets to enable css compression"
           end
-          if defined?(Uglifier)
-            @environment.register_postprocessor "application/javascript", ::Sprockets::JSMinifier
+          if js_compressor  = (options[:js_compressor]  || ::Sprockets::JSMinifier)
+            @environment.register_postprocessor "application/javascript", js_compressor
           else
-            puts "Add uglifier to your Gemfile to enable js minification"
+            puts "Add uglifier to your Gemfile or specify :js_compressor for sprockets to enable js minification"
           end
         end
 
-        extra_paths.each do |sprocket_path|
+        options[:paths].each do |sprocket_path|
           @environment.append_path sprocket_path
         end
       end


### PR DESCRIPTION
These changes allow the specification of :js_compressor and :css_compressor to the sprockets method. This can allow for custom compressor classes or for specifying one of sprockets's built-in compressors, as a symbol. Updated README to reflect new changes. The default is still the same for the compressors.
