### PR TITLE
Adding support for using assets directory for images.

### DIFF
--- a/lib/padrino/sprockets.rb
+++ b/lib/padrino/sprockets.rb
@@ -33,8 +33,9 @@ module Padrino
         # Change the folders to /assets/
         def asset_folder_name(kind)
           case kind
-          when :css then 'assets'
-          when :js  then 'assets'
+          when :css    then 'assets'
+          when :js     then 'assets'
+          when :images then 'assets'
           else kind.to_s
           end
         end


### PR DESCRIPTION
Added images directory to `AssetTagHelpers#asset_folder_name` so that image tags will also use the assets directory, as the JS and CSS helper tags do. This behavior is already noted in the usage section of the project readme but does not work as documented (ie, `image_tag` still looks in `public/images` rather than `app/assets/images`).
